### PR TITLE
refine error reporting on bad config

### DIFF
--- a/distro-build-client/installer.rkt
+++ b/distro-build-client/installer.rkt
@@ -135,10 +135,17 @@
                             base-name dist-suffix readme
                             sign-identity
                             (and notarization-config
-                                 (with-handlers ([exn:fail? (lambda (exn)
-                                                              (error 'notarization-config "bad encoding: ~s" notarization-config))])
-                                   (define ht (read (open-input-bytes (unpack-base64 notarization-config))))
-                                   (unless (hash? ht) (error "bad config"))
+                                 (let ()
+                                   (define ht
+                                     (with-handlers
+                                         ([exn:fail?
+                                           (lambda (exn)
+                                             (error 'notarization-config "bad encoding: ~s"
+                                                    notarization-config))])
+                                       (read (open-input-bytes
+                                              (unpack-base64 notarization-config)))))
+                                   (unless (hash? ht)
+                                     (error 'notarization-config "expected hash, got ~e" ht))
                                    ht))
                             #:hardened-runtime? hardened-runtime?))]
         [(windows)


### PR DESCRIPTION
In this PR I tighten the with-handlers a bit in the notarization code, it was swallowing the "not a hash" error message. It's hard to test this; IIRC the build process uses the version of distro-build that it compiled earlier in order to perform the bundling on the remote build machines. I've verified that it compiles, though, and AFAICT this isn't actually user-facing code.

I'll commit this code in a few days myself, if you don't feel the need to review it.