### PR TITLE
Preserve `description` field in package catalog

### DIFF
--- a/distro-build-server/pack-built.rkt
+++ b/distro-build-server/pack-built.rkt
@@ -76,7 +76,7 @@
                   'checksum (call-with-input-file* dest-zip sha1)
                   'name pkg
                   'author (hash-ref ht 'author "plt@racket-lang.org")
-                  'description (hash-ref ht 'author "library")
+                  'description (hash-ref ht 'description "library")
                   'tags (hash-ref ht 'tags '())
                   'dependencies (hash-ref ht 'dependencies '())
                   'modules (hash-ref ht 'modules '()))


### PR DESCRIPTION
Don't replace it with a duplicate of the `author` field.

Fixes https://github.com/racket/racket/issues/3727

I don't have a good setup for testing this locally right now.