### PR TITLE
generate `installers.rktd` and `.json` files with checksums

### DIFF
--- a/distro-build-doc/distro-build.scrbl
+++ b/distro-build-doc/distro-build.scrbl
@@ -115,7 +115,15 @@ cases).
 If a build fails for a machine, building continues on other machines.
 Success for a given machine means that its installer ends up in
 @filepath{build/installers} (and failure for a machine means no
-installer) as recorded in the @filepath{table.rktd} file.
+installer) as recorded in the @filepath{table.rktd} file. An
+@filepath{installers.rktd} file is also generated that maps each
+installer description to a hash table containing the installer's
+filename and its SHA1 and SHA256 checksums. Each @filepath{.rktd} file
+has a corresponding @filepath{.json} file with the same content in
+JSON format.
+
+@history[#:changed "1.24" @elem{Added @filepath{installers.rktd} and
+                                 @filepath{.json} file generation.}]
 
 To use the @tt{site} makefile target, the configuration file must at
 least provide a @racket[#:dist-base-url] value, which is a URL at which the
@@ -1585,10 +1593,13 @@ With this configuration file in @filepath{site.rkt},
 
 @commandline{make installers CONFIG=site.rkt}
 
-produces two installers, both in @filepath{build/installers}, and a
-hash table in @filepath{table.rktd} that maps
+produces two installers, both in @filepath{build/installers}, a
+hash table in @filepath{table.rktd} (and @filepath{table.json}) that maps
 @racket["Windows (64-bit x64)"] to the Windows installer
-and @racket["Mac OS (64-bit Intel)"] to the Mac OS installer.
+and @racket["Mac OS (64-bit Intel)"] to the Mac OS installer, and an
+@filepath{installers.rktd} (and @filepath{installers.json})
+that maps each description to a hash table with @racket['filename],
+@racket['sha1], and @racket['sha256] entries.
 
 While the client parts of this build are running, output is written to
 @filepath{build/log/Windows (64-bit x64)} and

--- a/distro-build-server/assemble-site.rkt
+++ b/distro-build-server/assemble-site.rkt
@@ -3,12 +3,14 @@
          racket/file
          racket/system
          racket/string
+         json
          net/url
          "download-page.rkt"
          "indexes.rkt"
          (only-in distro-build/config
                   extract-options+post-processes+aliases
                   infer-installer-alias)
+         (only-in distro-build/record-installer update-installers-checksums)
          (only-in plt-web site)
          (only-in xml write-xexpr))
 
@@ -173,10 +175,12 @@
 (copy log-dir)
 (generate-index-html dest-dir log-dir www-site)
 
-;; If all builds failed, installers director won't exist:
+;; If all builds failed, installers directory won't exist:
 (unless (file-exists? (build-path build-dir installers-dir "table.rktd"))
   (make-directory* (build-path build-dir installers-dir))
-  (call-with-output-file* (build-path build-dir installers-dir "table.rktd") (lambda (o) (write (hash) o))))
+  (for ([name (in-list '("table" "installers"))])
+    (call-with-output-file* (build-path build-dir installers-dir (string-append name ".rktd")) (lambda (o) (write (hash) o)))
+    (call-with-output-file* (build-path build-dir installers-dir (string-append name ".json")) (lambda (o) (write-json (hash) o)))))
 
 (copy installers-dir)
 (generate-index-html dest-dir installers-dir www-site)
@@ -186,6 +190,11 @@
               installers-dir
               "table.rktd"))
 (define installers-table (get-installers-table installers-table-path))
+
+(define installers-file-path
+  (build-path dest-dir
+              installers-dir
+              "installers.rktd"))
 
 (define logs-table-path
   (build-path dest-dir
@@ -198,7 +207,8 @@
     (when post-process
       (define args (append post-process (list (build-path dest-dir installers-dir installer))))
       (unless (apply system* args)
-        (error 'post-process "failed for ~s" args)))))
+        (error 'post-process "failed for ~s" args))))
+  (update-installers-checksums (build-path dest-dir installers-dir)))
 
 (for ([(name installer) (in-hash installers-table)])
   (define main+aliases (hash-ref aliases name #f))
@@ -220,7 +230,7 @@
 (copy "stamp.txt")
 (copy (build-path "origin" "collects.tgz"))
 
-(make-download-page installers-table-path
+(make-download-page installers-file-path
                     #:logs-table-file logs-table-path
                     #:plt-www-site www-site
                     #:logo logo

--- a/distro-build-server/download-page.rkt
+++ b/distro-build-server/download-page.rkt
@@ -6,7 +6,6 @@
          racket/date
          racket/file
          net/url
-         (only-in file/sha1 bytes->hex-string)
          scribble/html
          (only-in plt-web site page call-with-registered-roots)
          (only-in plt-web/style columns)
@@ -46,7 +45,7 @@
 
 (define (get-installers-table table-file)
   (define table (call-with-input-file table-file read))
-  (unless (hash? table) 
+  (unless (hash? table)
     (raise-user-error
      'make-download-page
      (~a "given file does not contain a hash table\n"
@@ -90,6 +89,9 @@
                        (if (hash-ref table-data k #f)
                            table-data
                            (hash-set table-data k v))))
+
+  (define (installer-filename inst)
+    (hash-ref inst 'filename))
 
   (define (system*/string . args)
     (define s (open-output-string))
@@ -210,13 +212,6 @@
         (list* " " (make-popup (list nbsp "?" nbsp) h))
         null))
   
-  (define (make-checksum path sha-bytes)
-    `(span ([class "checksum"])
-           ,(bytes->hex-string
-             (call-with-input-file*
-              path
-              sha-bytes))))
-
   (define page-site (and plt-style?
                          (site "download-page"
                                #:url "http://page.racket-lang.org/"
@@ -347,7 +342,7 @@
                        href: (url->string
                               (combine-url/relative
                                (string->url installers-url)
-                               inst))
+                               (installer-filename inst)))
                        (strip-detail last-col))))
                (get-site-help last-col))
               (td nbsp)
@@ -355,14 +350,14 @@
                       (span class: "detail" "")
                       (span class: "detail"
                             (~r (/ (file-size (build-path (path-only table-file)
-                                                          inst))
+                                                          (installer-filename inst)))
                                    (* 1024 1024))
                                 #:precision 1)
                             " MB")))
               (td nbsp)
               (td (if (past-success? inst)
                       (span class: "detail"
-                            (if (and log-dir 
+                            (if (and log-dir
                                      (file-exists? (build-path log-dir (hash-ref logs-table key key))))
                                 (list
                                  (a href: (url->string
@@ -375,8 +370,9 @@
                             "last success: "
                             (a href: (~a (past-success-relative-url inst))
                                (past-success-name inst)))
-                      (let ([path (build-path (path-only table-file)
-                                              inst)])
+                      (let ()
+                        (define (checksum-xexpr str)
+                          `(span ([class "checksum"]) ,str))
                         (if checksum-in-popup?
                             (span class: "detail"
                                   style: "position: relative"
@@ -385,11 +381,11 @@
                                    (list nbsp nbsp "click for SHA1 and SHA256" nbsp nbsp)
                                    `(span
                                      (div "SHA1:" nbsp
-                                          ,(make-checksum path sha1-bytes))
+                                          ,(checksum-xexpr (hash-ref inst 'sha1 "")))
                                      (div "SHA256:" nbsp
-                                          ,(make-checksum path sha256-bytes)))))
+                                          ,(checksum-xexpr (hash-ref inst 'sha256 ""))))))
                             (span class: "tinydetail"
-                                  "SHA256:" nbsp (xexpr->html (make-checksum path sha256-bytes)))))))
+                                  "SHA256:" nbsp (xexpr->html (checksum-xexpr (hash-ref inst 'sha256 ""))))))))
               (let ([current-rx (or current-rx
                                     (and version->current-rx
                                          (version->current-rx
@@ -404,7 +400,7 @@
                                                   key
                                                   (if (past-success? inst)
                                                       (past-success-file inst)
-                                                      inst))])
+                                                      (installer-filename inst)))])
                                  (if (regexp-match? current-rx inst-path)
                                      (a href: (url->string
                                                (combine-url/relative

--- a/distro-build-server/info.rkt
+++ b/distro-build-server/info.rkt
@@ -2,7 +2,7 @@
 
 (define collection "distro-build")
 
-(define version "1.23")
+(define version "1.24")
 
 (define deps '(["base" #:version "8.14.0.2"]
                "distro-build-client"

--- a/distro-build-server/manage-snapshots.rkt
+++ b/distro-build-server/manage-snapshots.rkt
@@ -83,6 +83,7 @@
 (printf "Loading past successes\n")
 (flush-output)
 (define table-file (build-path site-dir installers-dir "table.rktd"))
+(define installers-file (build-path site-dir installers-dir "installers.rktd"))
 (define current-table (get-installers-table table-file))
 (define rev-current-table (for/hash ([(k v) (in-hash current-table)])
                             (values v k)))
@@ -177,7 +178,7 @@
                    current-rx)))))
 
 (printf "Generating web page\n")
-(make-download-page table-file
+(make-download-page installers-file
                     #:logs-table-file logs-table-file
                     #:title site-title
                     #:window-title site-window-title

--- a/distro-build-server/record-installer.rkt
+++ b/distro-build-server/record-installer.rkt
@@ -1,12 +1,26 @@
 #lang racket/base
-(require racket/file)
+(require racket/file
+         json
+         (only-in file/sha1 bytes->hex-string))
 
 (provide record-installer
-         record-log-file)
+         record-log-file
+         update-installers-checksums)
 
-(define (update-table table-file filename desc)
+(define (write-json-file rktd-file table)
+  (define json-file (path-replace-extension rktd-file #".json"))
+  (define json-table
+    (for/hash ([(k v) (in-hash table)])
+      (values (string->symbol k) v)))
+  (call-with-output-file json-file
+    #:exists 'truncate/replace
+    (lambda (o)
+      (write-json json-table o)
+      (newline o))))
+
+(define (update-table table-file value desc)
   (when desc
-    (call-with-file-lock/timeout 
+    (call-with-file-lock/timeout
      #:max-delay 2
      table-file
      'exclusive
@@ -16,16 +30,46 @@
                       (call-with-input-file* table-file read)
                       (hash))
                   desc
-                  filename))
+                  value))
        (call-with-output-file table-file
          #:exists 'truncate/replace
-         (lambda (o) 
+         (lambda (o)
            (write t o)
-           (newline o))))
+           (newline o)))
+       (write-json-file table-file t))
      void)))
 
+(define (file-checksums path)
+  (if (file-exists? path)
+      (hash 'sha1 (bytes->hex-string
+                    (call-with-input-file* path sha1-bytes))
+            'sha256 (bytes->hex-string
+                     (call-with-input-file* path sha256-bytes)))
+      (hash 'sha1 "" 'sha256 "")))
+
 (define (record-installer dir filename desc)
-  (update-table (build-path dir "table.rktd") filename desc))
+  (update-table (build-path dir "table.rktd") filename desc)
+  (define checksums (file-checksums (build-path dir filename)))
+  (update-table (build-path dir "installers.rktd")
+                (hash-set checksums 'filename filename)
+                desc))
+
+;; Recompute checksums for all entries in installers.rktd
+;; based on the actual files in dir
+(define (update-installers-checksums dir)
+  (define table-file (build-path dir "installers.rktd"))
+  (when (file-exists? table-file)
+    (define updated
+      (for/hash ([(desc entry) (in-hash (call-with-input-file* table-file read))])
+        (define filename (hash-ref entry 'filename))
+        (define checksums (file-checksums (build-path dir filename)))
+        (values desc (hash-set checksums 'filename filename))))
+    (call-with-output-file table-file
+      #:exists 'truncate/replace
+      (lambda (o)
+        (write updated o)
+        (newline o)))
+    (write-json-file table-file updated)))
 
 (define (record-log-file dir log-file desc)
   (update-table (build-path dir "logs-table.rktd") log-file desc))


### PR DESCRIPTION
Add a new `installers.rktd` file that maps installer descriptions to hash tables containing the filename, SHA1, and SHA256 checksums. The existing `table.rktd` format is unchanged for backward compatibility. The download page reads checksums from `installers.rktd` instead of computing them on the fly. Checksums are recomputed after any post-processing steps to ensure they reflect the final files. All `.rktd` files also get a corresponding `.json` file with the same content.